### PR TITLE
Update Resolución del ejercicio.md

### DIFF
--- a/Horario 7022/Ejercicio Grupo 1/Resolución del ejercicio.md
+++ b/Horario 7022/Ejercicio Grupo 1/Resolución del ejercicio.md
@@ -1,2 +1,21 @@
 DESARROLLO DEL PROBLEMA: 
 
+CONCLUSIONES
+
+Legalización: 
+HT: Las personas que nunca permitirían un aborto mostrarían menos aprobación de la legalización en comparación con los que sí la permitirían
+Ho: P1=P2
+H1: P1<P2
+Podemos observar que las personas que siempre permiten el aborto presentarían mayor aprobación hacia la legalización del aborto en comparación con las personas que nunca permitirían el aborto.
+
+Política: 
+HT: Se espera que cada posición hacia el aborto presente una posición política distinta pero no se sabe cómo se daría la relación
+Ho: P1=P2
+H1: P1≠P2
+Podemos observar que sí hay diferencias significativas en la posición política con respecto a la posición frente al aborto. En cuanto a la posición de nunca permitir el aborto habría una mayor proporción de personas que pertenecen a la posición política de derecha. Las personas que solo aceptan el aborto en caso de violación tienen una mayor proporción en la posición política de centro derecha. Con respecto a la posición de permitir el aborto, se observa una mayor proporción de personas que pertenecen a la posición política de izquierda. Las personas que solo permiten el aborto en caso de Salud muestran una mayor distribución en la posición política de centro izquierda.
+
+Moral: 
+HT: Se cree que quienes nunca permitirían un aborto tendrían menor aceptación moral en hacia la realización del aborto que quienes sí lo permitirían
+Ho: P1=P2
+H1: P1<P2
+La mayor proporción de personas que nunca permitirían el aborto, consideraría que nunca es moralmente aceptable que una mujer realice un aborto. Mientras que las personas que siempre lo permitirían, no lo consideran un tema moral.


### PR DESCRIPTION
CONCLUSIONES
(Keny Codarlupo)
Legalización: 
HT: Las personas que nunca permitirían un aborto mostrarían menos aprobación de la legalización en comparación con los que sí la permitirían
Ho: P1=P2
H1: P1<P2
Podemos observar que las personas que siempre permiten el aborto presentarían mayor aprobación hacia la legalización del aborto en comparación con las personas que nunca permitirían el aborto.
Política: 
HT: Se espera que cada posición hacia el aborto presente una posición política distinta pero no se sabe cómo se daría la relación
Ho: P1=P2
H1: P1≠P2
Podemos observar que sí hay diferencias significativas en la posición política con respecto a la posición frente al aborto. En cuanto a la posición de nunca permitir el aborto habría una mayor proporción de personas que pertenecen a la posición política de derecha. Las personas que solo aceptan el aborto en caso de violación tienen una mayor proporción en la posición política de centro derecha. Con respecto a la posición de permitir el aborto, se observa una mayor proporción de personas que pertenecen a la posición política de izquierda. Las personas que solo permiten el aborto en caso de Salud muestran una mayor distribución en la posición política de centro izquierda.
Moral: 
HT: Se cree que quienes nunca permitirían un aborto tendrían menor aceptación moral en hacia la realización del aborto que quienes sí lo permitirían
Ho: P1=P2
H1: P1<P2
La mayor proporción de personas que nunca permitirían el aborto, consideraría que nunca es moralmente aceptable que una mujer realice un aborto. Mientras que las personas que siempre lo permitirían, no lo consideran un tema moral.
