### PR TITLE
Update Resolución del ejercicio.md

### DIFF
--- a/Horario 7022/Ejercicio Grupo 4/Resolución del ejercicio.md
+++ b/Horario 7022/Ejercicio Grupo 4/Resolución del ejercicio.md
@@ -1,2 +1,21 @@
 DESARROLLO DEL PROBLEMA: 
+ANÁLISIS ESTADÍSTICO DE LA VARIABLE VÍNCULO
+Al asumirse normalidad en las variables, no se realizan pruebas adicionales para evaluar la distribución normal de los datos. Por lo tanto se realizaran análisis estadísticos paramétricos.
+Para la hipótesis se plantea una comparación de medias, en este caso muestras independientes, por lo que se usa la prueba t-Student para muestras independientes. Sin embargo al tener en la variable “Vínculo” puntuaciones de “no responde” no se tomará en cuenta esta pues no aporta en nuestra hipótesis de trabajo, es así que sólo se tomarán los que sí respondieron. De este modo la Hipótesis específica es quienes mantienen contacto con su familia presentan menores niveles a comparación de quienes han perdido este vínculo.
+H0: μ (Si mantienen vínculo con la familia) = μ (No mantienen vínculo con la familia)
+H1: μ (Si mantiene vínculo con la familia) < μ (No mantiene vínculo con la familia)
+Debido a que las muestras son independientes, se tiene que realizar la prueba de contraste de varianzas, para determinar cómo son las varianzas de los grupos, y qué tipo de significancia se observa en el contraste de medias.
+Contraste de Varianzas
+H0: Las varianzas son homogéneas (varianzas iguales)
+H1: Las varianzas son heterogéneas (varianzas diferentes)
+A partir de la “Prueba de Levene para la igualdad de las varianzas”, se observa que la significancia (0.78) es mayor a 0.05; lo que lleva a aceptar la hipótesis nula de igualdad de varianzas (homogeneidad de varianzas).
+Contraste de medias
+H0: μ (Si mantienen vínculo con la familia) = μ (No mantienen vínculo con la familia)
+H1: μ (Si mantienen vínculo con la familia) < μ (No mantienen vínculo con la familia)
+Debido a que se encontraron varianzas homogéneas, sólo se observan los valores de la fila que indica varianzas iguales. 
+El contraste es bilateral, por lo que se observa la significancia que brinda la tabla, mostrando un valor de 0.78, que es mayor a 0.05. Por lo tanto, se acepta H0, las medias de ambos grupos de presidiarios (con o sin hijos), presentan puntajes similares en el manejo de la ira.
+Conclusión
+Se acepta la hipótesis nula, eso quiere decir que las medias de ambos grupos, los que mantienen vínculo con su familia y los que no, son iguales. Este resultado se podría explicar considerando que los valores de sus medias y desviaciones estándar son similares, por lo tanto no se observan diferencias marcadas en sus puntuaciones.
+Respecto a la variable vínculo, se puede decir que no genera variabilidad en las puntuaciones de manejo de la ira, por lo que independientemente del grupo al que pertenezca el presidiario, su puntuación será cercana a la media, y no presentará mayores diferencias.
+
 

--- a/Horario 7022/Ejercicio Grupo 4/Resolución del ejercicio.md
+++ b/Horario 7022/Ejercicio Grupo 4/Resolución del ejercicio.md
@@ -1,19 +1,27 @@
 DESARROLLO DEL PROBLEMA: 
-ANÁLISIS ESTADÍSTICO DE LA VARIABLE VÍNCULO
+ANÁLISIS ESTADÍSTICO DE LA VARIABLE VÍNCULO (Giovanny)
+
 Al asumirse normalidad en las variables, no se realizan pruebas adicionales para evaluar la distribución normal de los datos. Por lo tanto se realizaran análisis estadísticos paramétricos.
 Para la hipótesis se plantea una comparación de medias, en este caso muestras independientes, por lo que se usa la prueba t-Student para muestras independientes. Sin embargo al tener en la variable “Vínculo” puntuaciones de “no responde” no se tomará en cuenta esta pues no aporta en nuestra hipótesis de trabajo, es así que sólo se tomarán los que sí respondieron. De este modo la Hipótesis específica es quienes mantienen contacto con su familia presentan menores niveles a comparación de quienes han perdido este vínculo.
+
 H0: μ (Si mantienen vínculo con la familia) = μ (No mantienen vínculo con la familia)
 H1: μ (Si mantiene vínculo con la familia) < μ (No mantiene vínculo con la familia)
+
 Debido a que las muestras son independientes, se tiene que realizar la prueba de contraste de varianzas, para determinar cómo son las varianzas de los grupos, y qué tipo de significancia se observa en el contraste de medias.
+
 Contraste de Varianzas
 H0: Las varianzas son homogéneas (varianzas iguales)
 H1: Las varianzas son heterogéneas (varianzas diferentes)
+
 A partir de la “Prueba de Levene para la igualdad de las varianzas”, se observa que la significancia (0.78) es mayor a 0.05; lo que lleva a aceptar la hipótesis nula de igualdad de varianzas (homogeneidad de varianzas).
+
 Contraste de medias
 H0: μ (Si mantienen vínculo con la familia) = μ (No mantienen vínculo con la familia)
 H1: μ (Si mantienen vínculo con la familia) < μ (No mantienen vínculo con la familia)
+
 Debido a que se encontraron varianzas homogéneas, sólo se observan los valores de la fila que indica varianzas iguales. 
 El contraste es bilateral, por lo que se observa la significancia que brinda la tabla, mostrando un valor de 0.78, que es mayor a 0.05. Por lo tanto, se acepta H0, las medias de ambos grupos de presidiarios (con o sin hijos), presentan puntajes similares en el manejo de la ira.
+
 Conclusión
 Se acepta la hipótesis nula, eso quiere decir que las medias de ambos grupos, los que mantienen vínculo con su familia y los que no, son iguales. Este resultado se podría explicar considerando que los valores de sus medias y desviaciones estándar son similares, por lo tanto no se observan diferencias marcadas en sus puntuaciones.
 Respecto a la variable vínculo, se puede decir que no genera variabilidad en las puntuaciones de manejo de la ira, por lo que independientemente del grupo al que pertenezca el presidiario, su puntuación será cercana a la media, y no presentará mayores diferencias.


### PR DESCRIPTION
ANÁLISIS ESTADÍSTICO DE LA VARIABLE VÍNCULO
Al asumirse normalidad en las variables, no se realizan pruebas adicionales para evaluar la distribución normal de los datos. Por lo tanto se realizaran análisis estadísticos paramétricos.
Para la hipótesis se plantea una comparación de medias, en este caso muestras independientes, por lo que se usa la prueba t-Student para muestras independientes. Sin embargo al tener en la variable “Vínculo” puntuaciones de “no responde” no se tomará en cuenta esta pues no aporta en nuestra hipótesis de trabajo, es así que sólo se tomarán los que sí respondieron. De este modo la Hipótesis específica es quienes mantienen contacto con su familia presentan menores niveles a comparación de quienes han perdido este vínculo.
H0: μ (Si mantienen vínculo con la familia) = μ (No mantienen vínculo con la familia)
H1: μ (Si mantiene vínculo con la familia) < μ (No mantiene vínculo con la familia)
Debido a que las muestras son independientes, se tiene que realizar la prueba de contraste de varianzas, para determinar cómo son las varianzas de los grupos, y qué tipo de significancia se observa en el contraste de medias.
Contraste de Varianzas
H0: Las varianzas son homogéneas (varianzas iguales)
H1: Las varianzas son heterogéneas (varianzas diferentes)
A partir de la “Prueba de Levene para la igualdad de las varianzas”, se observa que la significancia (0.78) es mayor a 0.05; lo que lleva a aceptar la hipótesis nula de igualdad de varianzas (homogeneidad de varianzas).
Contraste de medias
H0: μ (Si mantienen vínculo con la familia) = μ (No mantienen vínculo con la familia)
H1: μ (Si mantienen vínculo con la familia) < μ (No mantienen vínculo con la familia)
Debido a que se encontraron varianzas homogéneas, sólo se observan los valores de la fila que indica varianzas iguales. 
El contraste es bilateral, por lo que se observa la significancia que brinda la tabla, mostrando un valor de 0.78, que es mayor a 0.05. Por lo tanto, se acepta H0, las medias de ambos grupos de presidiarios (con o sin hijos), presentan puntajes similares en el manejo de la ira.
Conclusión
Se acepta la hipótesis nula, eso quiere decir que las medias de ambos grupos, los que mantienen vínculo con su familia y los que no, son iguales. Este resultado se podría explicar considerando que los valores de sus medias y desviaciones estándar son similares, por lo tanto no se observan diferencias marcadas en sus puntuaciones.
Respecto a la variable vínculo, se puede decir que no genera variabilidad en las puntuaciones de manejo de la ira, por lo que independientemente del grupo al que pertenezca el presidiario, su puntuación será cercana a la media, y no presentará mayores diferencias.
