### PR TITLE
Update Resolución del ejercicio.md

### DIFF
--- a/Horario 7022/Ejercicio Grupo 6/Resolución del ejercicio.md
+++ b/Horario 7022/Ejercicio Grupo 6/Resolución del ejercicio.md
@@ -1,2 +1,11 @@
 DESARROLLO DEL PROBLEMA: 
 
+Conclusion Final
+
+Finalmente, se puede concluir que, en realidad, el hecho de ser diagnosticado con el síndrome de burnout no es un factor determinante que influye en lo que es la remuneración económica. Asimismo, sí se encuentra una diferencia significativa en lo que es la variable sexo, ya que cuando no se presenta el síndrome influye de manera inversa, mientras que cuando sí se presenta influye de manera directa. Profundizando en este aspecto, es preciso resaltar que cuando no se presenta el síndrome burnout, el sexo femenino presenta menor remuneración, podríamos especular que este hecho un sesgo heteronormativo presente en nuestra sociedad. 
+Por otro lado, resulta interesante el hecho de que cuando sí se presenta el síndrome, el sexo pasa a ser una variable no influyente, lo cual representa el caso óptimo, tanto para los diagnosticados como para los no diagnosticados, es decir, el sexo no debería ser una variable influyente en ninguno de los casos.
+Asimismo, nuestro grupo concuerda en que variables tales como el nivel educativo y el afrontamiento son necesariamente determinantes en lo que respecta a la remuneración económica. Asimismo debemos recordar la condición inicial del análisis, especificada al principio del ejercicio, pues no existe normalidad de residuos en el grupo de los que no presentan burnout
+
+Limitaciones: 
+
+En primer lugar, el hecho de desconocer el contexto en el que se encuentra la muestra seleccionada se presenta como una limitación, ya que al entender el mismo, podríamos desarollar hipótesis más específicas sobre el campo laboral el cual se investiga.


### PR DESCRIPTION
Conclusion Final

Finalmente, se puede concluir que, en realidad, el hecho de ser diagnosticado con el síndrome de burnout no es un factor determinante que influye en lo que es la remuneración económica. Asimismo, sí se encuentra una diferencia significativa en lo que es la variable sexo, ya que cuando no se presenta el síndrome influye de manera inversa, mientras que cuando sí se presenta influye de manera directa. Profundizando en este aspecto, es preciso resaltar que cuando no se presenta el síndrome burnout, el sexo femenino presenta menor remuneración, podríamos especular que este hecho un sesgo heteronormativo presente en nuestra sociedad. 
Por otro lado, resulta interesante el hecho de que cuando sí se presenta el síndrome, el sexo pasa a ser una variable no influyente, lo cual representa el caso óptimo, tanto para los diagnosticados como para los no diagnosticados, es decir, el sexo no debería ser una variable influyente en ninguno de los casos.
Asimismo, nuestro grupo concuerda en que variables tales como el nivel educativo y el afrontamiento son necesariamente determinantes en lo que respecta a la remuneración económica. Asimismo debemos recordar la condición inicial del análisis, especificada al principio del ejercicio, pues no existe normalidad de residuos en el grupo de los que no presentan burnout

Limitaciones: 

En primer lugar, el hecho de desconocer el contexto en el que se encuentra la muestra seleccionada se presenta como una limitación, ya que al entender el mismo, podríamos desarollar hipótesis más específicas sobre el campo laboral el cual se investiga.
